### PR TITLE
Throughput harness using BenchmarkDotNet.

### DIFF
--- a/src/Serilog.Sinks.Async.PerformanceTests/Benchmarks.cs
+++ b/src/Serilog.Sinks.Async.PerformanceTests/Benchmarks.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Serilog.Sinks.Async.PerformanceTests
+{
+    [TestClass]
+    public class Benchmarks
+    {
+        [TestMethod]
+        public void Benchmark()
+        {
+            BenchmarkRunner.Run<ThroughputBenchmark>();
+        }
+    }
+}

--- a/src/Serilog.Sinks.Async.PerformanceTests/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Async.PerformanceTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Serilog.Sinks.Async.PerformanceTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Serilog.Sinks.Async.PerformanceTests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b7e8a281-b017-43c3-956d-905ea74f0484")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
+++ b/src/Serilog.Sinks.Async.PerformanceTests/Serilog.Sinks.Async.PerformanceTests.csproj
@@ -1,18 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{654AD496-5B0E-4435-8142-445CC57F1F81}</ProjectGuid>
+    <ProjectGuid>{B7E8A281-B017-43C3-956D-905EA74F0484}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Serilog.Sinks.Async</RootNamespace>
-    <AssemblyName>Serilog.Sinks.Async</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>Serilog.Sinks.Async.PerformanceTests</RootNamespace>
+    <AssemblyName>Serilog.Sinks.Async.PerformanceTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,6 +35,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.9.8.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.9.8\lib\net45\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
@@ -49,46 +56,64 @@
       <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Core" />
     <Reference Include="System.Management" />
     <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
-    <Compile Include="..\GlobalAssemblyInfo.cs">
-      <Link>Properties\GlobalAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="BufferedQueue.cs" />
-    <Compile Include="BufferedQueueSink.cs" />
-    <Compile Include="LoggerConfigurationExtensions.cs" />
+    <Compile Include="Benchmarks.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SignallingSink.cs" />
+    <Compile Include="ThroughputBenchmark.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="Serilog.Sinks.Async.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.Sinks.Async\Serilog.Sinks.Async.csproj">
+      <Project>{654ad496-5b0e-4435-8142-445cc57f1f81}</Project>
+      <Name>Serilog.Sinks.Async</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Serilog.Sinks.Async.PerformanceTests/SignallingSink.cs
+++ b/src/Serilog.Sinks.Async.PerformanceTests/SignallingSink.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Async.PerformanceTests
+{
+    class SignallingSink : ILogEventSink
+    {
+        readonly int _expectedCount;
+        int _current;
+        readonly ManualResetEvent _wh;
+
+        public SignallingSink(int expectedCount)
+        {
+            _expectedCount = expectedCount;
+            _wh = new ManualResetEvent(false);
+        }
+
+        public void Reset()
+        {
+            _wh.Reset();
+            _current = 0;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            if (Interlocked.Increment(ref _current) == _expectedCount)
+                _wh.Set();
+        }
+
+        public void Wait()
+        {
+            if (!_wh.WaitOne(60000))
+                throw new TimeoutException("Event was not signaled within 60s.");
+        }
+    }
+}

--- a/src/Serilog.Sinks.Async.PerformanceTests/ThroughputBenchmark.cs
+++ b/src/Serilog.Sinks.Async.PerformanceTests/ThroughputBenchmark.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Serilog.Sinks.Async.PerformanceTests
+{
+    public class ThroughputBenchmark
+    {
+        readonly ILogger _syncLogger, _asyncLogger;
+        readonly SignallingSink _signal;
+        readonly LogEvent _evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null, new MessageTemplate(new[] { new TextToken("Hello") }), new LogEventProperty[0]);
+
+        const int Count = 10000;
+
+        public ThroughputBenchmark()
+        {
+            _signal = new SignallingSink(Count);
+
+            _syncLogger = new LoggerConfiguration()
+                .WriteTo.Sink(_signal)
+                .CreateLogger();
+
+            _asyncLogger = new LoggerConfiguration()
+                .WriteTo.Async(a => a.Sink(_signal))
+                .CreateLogger();
+        }
+
+        [Setup]
+        public void Reset()
+        {
+            _signal.Reset();
+        }
+
+        [Benchmark(Baseline = true)]
+        public void Sync()
+        {
+            for (var i = 0; i < Count; ++i)
+            {
+                _syncLogger.Write(_evt);
+            }
+
+            // Will complete immediately, but makes the comparison fairer.
+            _signal.Wait();
+        }
+
+        [Benchmark]
+        public void Async()
+        {
+            for (var i = 0; i < Count; ++i)
+            {
+                _asyncLogger.Write(_evt);
+            }
+
+            _signal.Wait();
+        }
+    }
+}

--- a/src/Serilog.Sinks.Async.PerformanceTests/packages.config
+++ b/src/Serilog.Sinks.Async.PerformanceTests/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BenchmarkDotNet" version="0.9.8" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
+  <package id="Serilog" version="2.0.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.0.0" targetFramework="net452" />
+</packages>

--- a/src/Serilog.Sinks.Async.sln
+++ b/src/Serilog.Sinks.Async.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Async", "Serilog.Sinks.Async\Serilog.Sinks.Async.csproj", "{654AD496-5B0E-4435-8142-445CC57F1F81}"
 EndProject
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{657CA4
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{65BA0F86-1CE7-4EC1-9793-4190D8B5FC8F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Async.PerformanceTests", "Serilog.Sinks.Async.PerformanceTests\Serilog.Sinks.Async.PerformanceTests.csproj", "{B7E8A281-B017-43C3-956D-905EA74F0484}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,6 +42,10 @@ Global
 		{65BA0F86-1CE7-4EC1-9793-4190D8B5FC8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65BA0F86-1CE7-4EC1-9793-4190D8B5FC8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65BA0F86-1CE7-4EC1-9793-4190D8B5FC8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7E8A281-B017-43C3-956D-905EA74F0484}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7E8A281-B017-43C3-956D-905EA74F0484}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7E8A281-B017-43C3-956D-905EA74F0484}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E8A281-B017-43C3-956D-905EA74F0484}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Serilog.Sinks.Async/packages.config
+++ b/src/Serilog.Sinks.Async/packages.config
@@ -1,6 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net45" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net45" />
   <package id="Serilog" version="2.0.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I thought it might be handy to have a basic performance harness to both monitor the impact of changes and provide a basis for the inevitable process of discussing/tuning performance :-)

Currently only two basic benchmarks are run - a baseline directly to a (counting) sink, and the same test but via the `Async()` method.

Results land in a folder under `bin/Release`. Here's the first and only run on my machine:

```ini

Host Process Environment Information:
BenchmarkDotNet=v0.9.8.0
OS=Microsoft Windows NT 6.3.9600.0
Processor=Intel(R) Core(TM) i7-3720QM CPU 2.60GHz, ProcessorCount=8
Frequency=2533319 ticks, Resolution=394.7391 ns, Timer=TSC
CLR=MS.NET 4.0.30319.42000, Arch=32-bit ?
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1080.0

Type=ThroughputBenchmark  Mode=Throughput  GarbageCollection=Concurrent Workstation  

```
 Method |         Median |        StdDev | Scaled |
------- |--------------- |-------------- |------- |
   Sync |    618.8873 us |     5.1333 us |   1.00 |
  Async | 40,723.8488 us | 9,852.8591 us |  65.80 |
